### PR TITLE
[src/Makefile] Change paths and add missing flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,14 +1,15 @@
-CCFLAGS = -std=c99 -O3
+CCFLAGS += -std=c99 -O3
 
 TARGET = pixiewps
 CRYPTO = crypto/sha256.c crypto/md.c crypto/md_wrap.c
 SOURCE = $(TARGET).c random_r.c $(CRYPTO)
+PREFIX ?= $(DESTDIR)/usr
 PREFIX = $(DESTDIR)/usr
 BINDIR = $(PREFIX)/bin
-LOCDIR = $(PREFIX)/local/bin
+LOCDIR ?= $(PREFIX)/local
 
 all:
-	$(CC) $(CCFLAGS) -o $(TARGET) $(SOURCE)
+	$(CC) $(CFLAGS) $(CCFLAGS) $(CPPFLAGS) -o $(TARGET) $(SOURCE) $(LDFLAGS)
 
 debug:
 	$(CC) $(CCFLAGS) -DDEBUG -o $(TARGET) $(SOURCE)
@@ -16,8 +17,8 @@ debug:
 install:
 	rm -f $(BINDIR)/$(TARGET)
 	rm -f $(LOCDIR)/$(TARGET)
-	install -d $(LOCDIR)
-	install -m 755 $(TARGET) $(LOCDIR)
+	install -d $(DESTDIR)$(LOCDIR)$(BINDIR)
+	install -m 755 $(TARGET) $(DESTDIR)$(LOCDIR)$(BINDIR)
 
 uninstall:
 	rm $(LOCDIR)/$(TARGET)


### PR DESCRIPTION
Fix paths and add missing flags: LDFLAGS, CFLAGS and CPPFLAGS.
Also avoids dropping CCFLAGS passed during building (eg.: debhelper).
The authors of this patch are:
Sophie Brun <sophie@freexian.com>,
Samuel Henrique <samueloph@gmail.com>
Gianfranco Costamagna <locutusofborg@debian.org>